### PR TITLE
Google Cloud Build: Make app version constant.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,8 @@
 steps:
 - name: "gcr.io/cloud-builders/gcloud"
-  args: ["app", "deploy", 'app.yaml', '--version=$SHORT_SHA', '--promote']
+  args: ["app", "deploy", 'app.yaml', '--version=cd', '--promote']
 - name: "gcr.io/cloud-builders/gcloud"
-  args: ["app", "deploy", 'app-frontend.yaml', '--version=$SHORT_SHA', '--promote']
+  args: ["app", "deploy", 'app-frontend.yaml', '--version=cd', '--promote']
 - name: "gcr.io/cloud-builders/gcloud"
-  args: ["app", "deploy", 'app-cron.yaml', '--version=$SHORT_SHA', '--promote']
+  args: ["app", "deploy", 'app-cron.yaml', '--version=cd', '--promote']
 timeout: "4800s"


### PR DESCRIPTION
This means new continual deployment versions will replace old ones, meaning old and possibly insecure ones don't need manual deletion.