### PR TITLE
Use hash rather than all data as cache key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/jbeshir/predictionbook-extractor v0.0.0-20190213040432-8da3da8fe604
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
-	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
+	golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.42.0
 	google.golang.org/appengine v1.6.7

--- a/mlclient/predictionmaker.go
+++ b/mlclient/predictionmaker.go
@@ -1,7 +1,6 @@
 package mlclient
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -10,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/api/ml/v1"
 	"strings"
+
+	"golang.org/x/crypto/sha3"
 )
 
 type PredictionMaker struct {
@@ -116,9 +117,9 @@ func newMLRequest(predictions []float64) (*ml.GoogleCloudMlV1__PredictRequest, e
 }
 
 func generatePredictionCacheKey(predictions []float64) string {
-	var buf bytes.Buffer
+	hash := sha3.New512()
 	for _, p := range predictions {
-		binary.Write(&buf, binary.BigEndian, p)
+		binary.Write(hash, binary.BigEndian, p)
 	}
-	return base64.StdEncoding.EncodeToString(buf.Bytes())
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }

--- a/mlclient/predictionmaker_test.go
+++ b/mlclient/predictionmaker_test.go
@@ -49,7 +49,7 @@ func TestGeneratePredictionCacheKey(t *testing.T) {
 	t.Parallel()
 
 	key := generatePredictionCacheKey([]float64{0.4, 0.1})
-	expectedKey := "P9mZmZmZmZo/uZmZmZmZmg=="
+	expectedKey := "Fkrv+y+ZpLY+nq+1irp6jB4K5r6GaSHGnT0pbnWS50dZ5erOiuh6vw/l4vMOX6utlV88bh7JfSHmiEa4aVFSbA=="
 	if key != expectedKey {
 		t.Errorf("Incorrect generated prediction cache key; expected %v, was %v", expectedKey, key)
 	}


### PR DESCRIPTION
Caching was failing for larger numbers of predictions, creating costs from hitting ML Engine.